### PR TITLE
Changes for fixing the use of deprecated function in GuaranteedProces…

### DIFF
--- a/src/main/java/com/solace/samples/java/patterns/DirectProcessor.java
+++ b/src/main/java/com/solace/samples/java/patterns/DirectProcessor.java
@@ -17,12 +17,8 @@
 package com.solace.samples.java.patterns;
 
 
-import java.io.IOException;
-import java.util.Properties;
-
 import com.solace.messaging.MessagingService;
 import com.solace.messaging.config.SolaceProperties.AuthenticationProperties;
-import com.solace.messaging.config.SolaceProperties.MessageProperties;
 import com.solace.messaging.config.SolaceProperties.ServiceProperties;
 import com.solace.messaging.config.SolaceProperties.TransportLayerProperties;
 import com.solace.messaging.config.profile.ConfigurationProfile;
@@ -33,6 +29,9 @@ import com.solace.messaging.receiver.DirectMessageReceiver;
 import com.solace.messaging.receiver.MessageReceiver.MessageHandler;
 import com.solace.messaging.resources.Topic;
 import com.solace.messaging.resources.TopicSubscription;
+
+import java.io.IOException;
+import java.util.Properties;
 
 /**
  * A Processor is a microservice or application that receives a message, does something with the info,
@@ -108,9 +107,6 @@ public class DirectProcessor {
                 // how to "process" the incoming message? maybe do a DB lookup? add some additional properties? or change the payload?
                 final String upperCaseMessage = inboundTopic.toUpperCase();  // as a silly example of "processing"
                 
-                if (inboundMsg.getApplicationMessageId() != null) {  // populate for traceability
-                    messageBuilder.withProperty(MessageProperties.APPLICATION_MESSAGE_ID, inboundMsg.getApplicationMessageId());
-                }
                 OutboundMessage outboundMsg = messageBuilder.build(upperCaseMessage);  // build TextMessage to send
                 String [] inboundTopicLevels = inboundTopic.split("/",6);
                 String outboundTopic = new StringBuilder(TOPIC_PREFIX).append(API.toLowerCase())

--- a/src/main/java/com/solace/samples/java/patterns/GuaranteedProcessor.java
+++ b/src/main/java/com/solace/samples/java/patterns/GuaranteedProcessor.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2021-2022 Solace Corporation. All rights reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -18,7 +18,6 @@ package com.solace.samples.java.patterns;
 
 import com.solace.messaging.MessagingService;
 import com.solace.messaging.PubSubPlusClientException;
-import com.solace.messaging.config.SolaceProperties;
 import com.solace.messaging.config.SolaceProperties.AuthenticationProperties;
 import com.solace.messaging.config.SolaceProperties.ServiceProperties;
 import com.solace.messaging.config.SolaceProperties.TransportLayerProperties;
@@ -32,7 +31,6 @@ import com.solace.messaging.receiver.InboundMessage;
 import com.solace.messaging.receiver.PersistentMessageReceiver;
 import com.solace.messaging.resources.Queue;
 import com.solace.messaging.resources.Topic;
-import com.solacesystems.common.util.StringUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -42,9 +40,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-/** A sample application that publishes a message for every one that it receives.
- * Uses a synchronous receiver to block waiting for messages from the broker, and a 
- * non-blocking publisher to send. It uses a simple helper class to correlate 
+/**
+ * A sample application that publishes a message for every one that it receives.
+ * Uses a synchronous receiver to block waiting for messages from the broker, and a
+ * non-blocking publisher to send. It uses a simple helper class to correlate
  * successfully published outbound messages before it ACKs the received message.
  * This application assumes a queue named <code>q_java_proc</code> has already been
  * created for it, and the topic subscription <code>solace/samples/&ast;/pers/pub/></code>
@@ -55,9 +54,9 @@ public class GuaranteedProcessor {
     private static final String QUEUE_NAME = "q_java_proc";
     static final String TOPIC_PREFIX = "solace/samples/";  // used as the topic "root"
     private static final String API = "Java";
-    
+
 //    private static PersistentMessageReceiver receiver;
-    
+
     private static volatile int msgSentCounter = 0;                 // num messages sent
     private static volatile int msgRecvCounter = 0;                 // num messages received
     private static volatile boolean isShutdown = false;             // are we done?
@@ -65,7 +64,9 @@ public class GuaranteedProcessor {
     // remember to add log4j2.xml to your classpath
     private static final Logger logger = LogManager.getLogger();  // log4j2, but could also use SLF4J, JCL, etc.
 
-    /** This is the main app.  Use this type of app for receiving Guaranteed messages (e.g. via a queue endpoint). */
+    /**
+     * This is the main app.  Use this type of app for receiving Guaranteed messages (e.g. via a queue endpoint).
+     */
     public static void main(String... args) throws InterruptedException, IOException {
         if (args.length < 3) {  // Check command line arguments
             System.out.printf("Usage: %s <host:port> <message-vpn> <client-username> [password]%n%n", SAMPLE_NAME);
@@ -75,13 +76,13 @@ public class GuaranteedProcessor {
 
         final Properties properties = new Properties();
         properties.setProperty(TransportLayerProperties.HOST, args[0]);          // host:port
-        properties.setProperty(ServiceProperties.VPN_NAME,  args[1]);     // message-vpn
+        properties.setProperty(ServiceProperties.VPN_NAME, args[1]);     // message-vpn
         properties.setProperty(AuthenticationProperties.SCHEME_BASIC_USER_NAME, args[2]);      // client-username
         if (args.length > 3) {
             properties.setProperty(AuthenticationProperties.SCHEME_BASIC_PASSWORD, args[3]);  // client-password
         }
         //properties.setProperty(JCSMPProperties.GENERATE_SEQUENCE_NUMBERS, true);  // not required, but interesting
-        
+
         properties.setProperty(TransportLayerProperties.RECONNECTION_ATTEMPTS, "20");  // recommended settings
         properties.setProperty(TransportLayerProperties.CONNECTION_RETRIES_PER_HOST, "5");
         // https://docs.solace.com/Solace-PubSub-Messaging-APIs/API-Developer-Guide/Configuring-Connection-T.htm
@@ -91,17 +92,17 @@ public class GuaranteedProcessor {
                 .build();
         messagingService.connect();  // blocking connect
         messagingService.addServiceInterruptionListener(serviceEvent -> {
-            logger.warn("### SERVICE INTERRUPTION: "+serviceEvent.getCause());
+            logger.warn("### SERVICE INTERRUPTION: " + serviceEvent.getCause());
             //isShutdown = true;
         });
         messagingService.addReconnectionAttemptListener(serviceEvent -> {
-            logger.info("### RECONNECTING ATTEMPT: "+serviceEvent);
+            logger.info("### RECONNECTING ATTEMPT: " + serviceEvent);
         });
         messagingService.addReconnectionListener(serviceEvent -> {
-            logger.info("### RECONNECTED: "+serviceEvent);
+            logger.info("### RECONNECTED: " + serviceEvent);
         });
 
-        
+
         // build the publisher object
         final PersistentMessagePublisher publisher = messagingService.createPersistentMessagePublisherBuilder()
                 .onBackPressureWait(1)
@@ -115,11 +116,11 @@ public class GuaranteedProcessor {
                 .createPersistentMessageReceiverBuilder()
                 .build(Queue.durableExclusiveQueue(QUEUE_NAME));
         try {
-        	receiver.start();
+            receiver.start();
         } catch (RuntimeException e) {
             logger.error(e);
             System.err.printf("%n*** Could not establish a connection to queue '%s': %s%n", QUEUE_NAME, e.getMessage());
-            System.err.println("Create queue using PubSub+ Manager WebGUI, and add subscription " + 
+            System.err.println("Create queue using PubSub+ Manager WebGUI, and add subscription " +
                     TOPIC_PREFIX + "*/pers/pub/>");
             System.err.println("  or see the SEMP CURL scripts inside the 'semp-rest-api' directory.");
             // could also try to retry, loop and retry until successfully able to connect to the queue
@@ -137,7 +138,7 @@ public class GuaranteedProcessor {
             msgSentCounter = 0;
         }, 1, 1, TimeUnit.SECONDS);
 
-        
+
         while (System.in.available() == 0 && !isShutdown) {
             InboundMessage inboundMsg = receiver.receiveMessage(1000);  // blocking receive a message
             if (inboundMsg == null) {  // receive() either got interrupted, or timed out
@@ -148,25 +149,24 @@ public class GuaranteedProcessor {
             if (inboundTopic.contains("/pers/pub/")) {  // simple validation of topic
                 // how to "process" the incoming message? maybe do a DB lookup? add some additional properties? or change the payload?
                 OutboundMessageBuilder messageBuilder = messagingService.messageBuilder();
-                if (!StringUtil.isEmpty(inboundMsg.getApplicationMessageId())) {
-                    messageBuilder.withProperty(SolaceProperties.MessageProperties.APPLICATION_MESSAGE_ID, inboundMsg.getApplicationMessageId());// set the new message ID to the same as this one
-                }
                 final String upperCaseTopic = inboundTopic.toUpperCase();  // as a silly example of "processing"
                 OutboundMessage outboundMsg = messageBuilder.build(upperCaseTopic);
-                String[] inboundTopicLevels = inboundTopic.split("/", 6);
-                String onwardsTopic = new StringBuilder(TOPIC_PREFIX).append(API.toLowerCase())
-                        .append("/pers/upper/").append(inboundTopicLevels[5]).toString();
                 try {
+                    String[] inboundTopicLevels = inboundTopic.split("/", 6);
+                    String onwardsTopic = new StringBuilder(TOPIC_PREFIX).append(API.toLowerCase())
+                            .append("/pers/upper/").append(inboundTopicLevels[5]).toString();
                     ProcessorCorrelationKey ck = new ProcessorCorrelationKey(inboundMsg, outboundMsg, receiver);
                     publisher.publish(outboundMsg, Topic.of(onwardsTopic), ck);
                     msgSentCounter++;
+                } catch (ArrayIndexOutOfBoundsException arrayIndexOutOfBoundsException) {
+                    logger.warn("### Caught while trying to publisher.publish()", arrayIndexOutOfBoundsException);
                 } catch (
                         RuntimeException e) {  // threw from publish(), only thing that is throwing here, but keep trying (unless shutdown?)
-                    logger.warn("### Caught while trying to publisher.publish()",e);
+                    logger.warn("### Caught while trying to publisher.publish()", e);
                     isShutdown = true;  // just example, maybe look to see if recoverable
                 }
             } else {  // unexpected message. either log or something
-                logger.info("Received an unexpected message with topic "+inboundTopic+".  Ignoring");
+                logger.info("Received an unexpected message with topic " + inboundTopic + ".  Ignoring");
                 receiver.ack(inboundMsg);
             }
         }
@@ -176,7 +176,7 @@ public class GuaranteedProcessor {
         System.out.println(SAMPLE_NAME + " connected, and running. Press [ENTER] to quit.");
         while (System.in.available() == 0 && !isShutdown) {
             Thread.sleep(1000);  // wait 1 second
-            System.out.printf("%s %s Received msgs/s: %,d%n",API,SAMPLE_NAME,msgRecvCounter);  // simple way of calculating message rates
+            System.out.printf("%s %s Received msgs/s: %,d%n", API, SAMPLE_NAME, msgRecvCounter);  // simple way of calculating message rates
             msgRecvCounter = 0;
         }
         isShutdown = true;
@@ -187,47 +187,50 @@ public class GuaranteedProcessor {
         System.out.println("Main thread quitting.");
     }
 
-    
-    
+
     ////////////////////////////////////////////////////////////////////////////
-    
-    /** Hold onto both messages, wait for outbound ACK to come back, and then ACK inbound message */
+
+    /**
+     * Hold onto both messages, wait for outbound ACK to come back, and then ACK inbound message
+     */
     private static class ProcessorCorrelationKey {
-        
+
         private final InboundMessage inboundMsg;
         private final OutboundMessage outboundMsg;
         private final PersistentMessageReceiver receiver;
-        
+
         private ProcessorCorrelationKey(InboundMessage inboundMsg, OutboundMessage outboundMsg, PersistentMessageReceiver receiver) {
             this.inboundMsg = inboundMsg;
             this.outboundMsg = outboundMsg;
             this.receiver = receiver;
         }
     }
-    
+
     //////////////////////////////////
-    
-    /** Very simple static inner class, used for handling publish ACKs/NACKs from broker. **/
+
+    /**
+     * Very simple static inner class, used for handling publish ACKs/NACKs from broker.
+     **/
     private static class PublishCallbackHandler implements MessagePublishReceiptListener {
 
-		@Override
-		public void onPublishReceipt(PublishReceipt publishReceipt) {
+        @Override
+        public void onPublishReceipt(PublishReceipt publishReceipt) {
             Object userContext = publishReceipt.getUserContext();  // optionally set at publish()
             assert userContext instanceof ProcessorCorrelationKey;
-            ProcessorCorrelationKey ck = (ProcessorCorrelationKey)userContext;
-			if (publishReceipt.getException() != null) {  // NACK, something went wrong
-	            final PubSubPlusClientException e = publishReceipt.getException();
+            ProcessorCorrelationKey ck = (ProcessorCorrelationKey) userContext;
+            if (publishReceipt.getException() != null) {  // NACK, something went wrong
+                final PubSubPlusClientException e = publishReceipt.getException();
                 logger.warn(String.format("NACK for Message %s - %s", ck.outboundMsg, e));
                 // probably want to do something here.  some error handling possibilities:
                 //  - send the message again
                 //  - send it somewhere else (error handling queue?)
                 //  - log and continue
                 //  - pause and retry (backoff) - maybe set a flag to slow down the publisher
-			} else {  // regular ACK of message, successful publish
-	            ck.receiver.ack(ck.inboundMsg);  // ONLY ACK inbound msg off my queue once outbound msg is Guaranteed delivered
-	            logger.debug(String.format("ACK for Message %s", ck));  // good enough, the broker has it now
-			}
-		}
+            } else {  // regular ACK of message, successful publish
+                ck.receiver.ack(ck.inboundMsg);  // ONLY ACK inbound msg off my queue once outbound msg is Guaranteed delivered
+                logger.debug(String.format("ACK for Message %s", ck));  // good enough, the broker has it now
+            }
+        }
     }
 
 }

--- a/src/main/java/com/solace/samples/java/patterns/GuaranteedProcessor.java
+++ b/src/main/java/com/solace/samples/java/patterns/GuaranteedProcessor.java
@@ -16,17 +16,9 @@
 
 package com.solace.samples.java.patterns;
 
-import java.io.IOException;
-import java.util.Properties;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import com.solace.messaging.MessagingService;
 import com.solace.messaging.PubSubPlusClientException;
+import com.solace.messaging.config.SolaceProperties;
 import com.solace.messaging.config.SolaceProperties.AuthenticationProperties;
 import com.solace.messaging.config.SolaceProperties.ServiceProperties;
 import com.solace.messaging.config.SolaceProperties.TransportLayerProperties;
@@ -40,6 +32,14 @@ import com.solace.messaging.receiver.InboundMessage;
 import com.solace.messaging.receiver.PersistentMessageReceiver;
 import com.solace.messaging.resources.Queue;
 import com.solace.messaging.resources.Topic;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.util.Properties;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 /** A sample application that publishes a message for every one that it receives.
  * Uses a synchronous receiver to block waiting for messages from the broker, and a 
@@ -147,7 +147,7 @@ public class GuaranteedProcessor {
             if (inboundTopic.contains("/pers/pub/")) {  // simple validation of topic
                 // how to "process" the incoming message? maybe do a DB lookup? add some additional properties? or change the payload?
                 OutboundMessageBuilder messageBuilder = messagingService.messageBuilder();
-                messageBuilder.withApplicationMessageId(inboundMsg.getApplicationMessageId());  // set the new message ID to the same as this one
+                messageBuilder.withProperty(SolaceProperties.MessageProperties.APPLICATION_MESSAGE_ID, inboundMsg.getProperty(SolaceProperties.MessageProperties.APPLICATION_MESSAGE_ID));// set the new message ID to the same as this one
                 final String upperCaseTopic = inboundTopic.toUpperCase();  // as a silly example of "processing"
                 OutboundMessage outboundMsg = messageBuilder.build(upperCaseTopic);
                 String [] inboundTopicLevels = inboundTopic.split("/",6);


### PR DESCRIPTION
The api method `OutboundMessageBuilder.withApplicationMessageId()` is deprecated and the gradle build was complaining about it.
An issue was raised for addressing this : [Issue-16](https://github.com/SolaceSamples/solace-samples-java/issues/16)

The change in this PR replaces the deprecated function with the new api for getting the applicationMessageId.
With a round of testing the E2E functionality is verified.

However, when logging the applicationMessageId on the inboundMessage, it comes as Null.
The same behaviour is observed with the deprecated method and also on the JCSMP example. The JCSMP example seems to expect this situation and sets the applicationMessageId on the outboundMessage when its present in the inboundMessage.
Logs for the behaviour:

`--LOG-- 14:36:45.494 [main] INFO  com.solac.sampl.java.patte.GuaranteedProcessor - The inbound message is :InboundMessage{, discardNotification=MessageDiscardNotification{hasBrokerDiscardIndication=false, hasInternalDiscardIndication=false}, solaceMessage=Destination:                            Topic 'solace/samples/jcsmp/pers/pub/GuaranteedProcessorTestingJcsmp'
SenderId:                               Try-Me-Pub/solclientjs/chrome-106.0.0-OSX-10.15.7/1236185041/0001
SendTimestamp:                          1667309654846 (Tue Nov 01 2022 14:34:14.846)
Class Of Service:                       USER_COS_1
DeliveryMode:                           NON_PERSISTENT
Message Id:                             167
Replication Group Message ID:           rmid1:190e0-5d5d73e4fe6-00000000-000000a7
Binary Attachment:                      len=54
  48 65 6c 6c 6f 20 77 6f    72 6c 64 20 74 6f 20 74    Hello.world.to.t
  68 65 20 47 75 61 72 61    6e 74 65 65 64 50 72 6f    he.GuaranteedPro
  63 65 73 73 6f 72 20 71    75 65 75 65 20 76 69 61    cessor.queue.via
  20 6a 73 63 6d 70                                     .jscmp

}
--LOG-- 14:36:45.494 [main] INFO  com.solac.sampl.java.patte.GuaranteedProcessor - The inbound ApplicationMessageId is :null
--LOG-- 14:36:45.494 [main] INFO  com.solac.sampl.java.patte.GuaranteedProcessor - The inbound application message id via properties is :null
--LOG-- 14:36:45.495 [main] INFO  com.solac.sampl.java.patte.GuaranteedProcessor - The outbound message is :MessageImpl{solaceMessage=com.solace.messaging.util.internal.OutboundMessageTemplate[messageId=0,ackMessageId=0,prevId=0,CID_count=0,userData=,type=DIRECT,redelivered=false,timeToLive=0,expiration=0,dmqEligible=true,topicSeqNum=null,metadataLen=0,contentLen=0,attLen=65,sendAttemptedOnce=false,ackImmediately=false,safeToRelease=false,retransmitting=false,sendCount=0@77e80a5e]}
`

